### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/dupan.el
+++ b/dupan.el
@@ -32,6 +32,11 @@
 (require 'url-http)
 (require 'dired-aux)
 
+(eval-when-compile
+  (defvar url-http-end-of-headers)
+  (defvar url-http-content-type)
+  (defvar url-http-response-status))
+
 (defgroup dupan nil
   "百度网盘客户端。"
   :prefix "dupan-"


### PR DESCRIPTION
```
In dupan-make-request:
dupan.el:124:46: Warning: reference to free variable ‘url-http-response-status’
dupan.el:126:77: Warning: reference to free variable ‘url-http-end-of-headers’
dupan.el:128:68: Warning: reference to free variable ‘url-http-content-type’
```